### PR TITLE
`Dependabot` approvers

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -6,8 +6,6 @@ update_configs:
     update_schedule: "live"
     default_reviewers:
     - asmega
-    - emileswarts
-    - tommotaylor
-    - cob16
     - sequencemedialimited
-
+    - mattempty
+    - form-builder-developers


### PR DESCRIPTION
Remove Made Tech developers from Dependabot